### PR TITLE
Major update.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,34 @@
-pan-chainguard - Preload Trusted CA Intermediate Certificate Chains on PAN-OS
-=============================================================================
+pan-chainguard - Manage Root Store and Intermediate Certificate Chains on PAN-OS
+================================================================================
 
 ``pan-chainguard`` is a Python3 application which uses
 `CCADB data
 <https://www.ccadb.org/resources>`_
-to derive intermediate certificate chains for trusted
-certificate authorities in PAN-OS so they can be
-`preloaded
-<https://wiki.mozilla.org/Security/CryptoEngineering/Intermediate_Preloading>`_
-as device certificates.
+and allows PAN-OS SSL decryption administrators to:
 
-Problem
+#. Create a custom, up-to-date trusted root store for PAN-OS.
+#. Determine intermediate certificate chains for trusted Certificate
+   Authorities in PAN-OS so they can be `preloaded
+   <https://wiki.mozilla.org/Security/CryptoEngineering/Intermediate_Preloading>`_
+   as device certificates.
+
+Issue 1
+-------
+
+The PAN-OS root store (*Default Trusted Certificate Authorities*) is
+updated only in PAN-OS major software releases; it is not currently
+managed by content updates.  The root store for PAN-OS 10.x.x releases
+is now over 4 years old.
+
+The impact for PAN-OS SSL decryption administrators is when the root
+CA for the server certificate is not trusted, the firewall will
+provide the forward untrust certificate to the client.  End users will
+then see errors such as *NET::ERR_CERT_AUTHORITY_INVALID* (Chrome) or
+*SEC_ERROR_UNKNOWN_ISSUER* (Firefox) until the missing trusted CAs are
+identified, the certificates are obtained, and the certificates are
+imported into PAN-OS.
+
+Issue 2
 -------
 
 Many TLS enabled origin servers suffer from a misconfiguration in
@@ -18,8 +36,8 @@ which they:
 
 #. Do not return intermediate CA certificates.
 #. Return certificates out of order.
-#. Return intermediate certificates which are not related to the CA
-   which signed the server certificate.
+#. Return intermediate certificates which are not related to the root
+   CA for the server certificate.
 
 The impact for PAN-OS SSL decryption administrators is end users will
 see errors such as *unable to get local issuer certificate* until the
@@ -29,8 +47,23 @@ sites that are misconfigured are
 the required intermediate certificates are obtained, and the
 certificates are imported into PAN-OS.
 
-Solution: Intermediate CA Preloading
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Solution 1: Create Custom Root Store
+------------------------------------
+
+``pan-chainguard`` can create a custom root store, using one or more
+of the major vendor root stores, which are managed by their CA
+certificate program:
+
++ `Mozilla <https://wiki.mozilla.org/CA>`_
++ `Apple <https://www.apple.com/certificateauthority/ca_program.html>`_
++ `Microsoft <https://aka.ms/RootCert>`_
++ `Google Chrome <https://g.co/chrome/root-policy>`_
+
+The custom root store can then be added to PAN-OS as trusted CA device
+certificates.
+
+Solution 2: Intermediate CA Preloading
+--------------------------------------
 
 ``pan-chainguard`` uses a root store and the
 *All Certificate Information (root and intermediate) in CCADB (CSV)*

--- a/TODO.rst
+++ b/TODO.rst
@@ -1,23 +1,15 @@
 pan-chainguard To Do List
 =========================
 
-- Split chain.py into separate programs for:
+- Enhance guard.py to allow update of existing certificates vs.
+  delete all, then re-add all.
 
-  + Intermediate certificate discovery
-  + Certificate download
-
-- Re-implement chain.py to use a tree.
-
-- Enhance chain.py to provide a visual representation of the
-  certificate hierarchy.
-
-- Provide alternate certificate sources besides downloading from
-  crt.sh.  For example, create a separate content git repository.
-
-- Add automated tests; consider using Python unittest unit testing
-  framework.
+- Update admin guide with use cases (e.g., update root store
+  only).
 
 - Optimise XML API usage for increased performance; consider use
   of multi-config.
 
 - Retry transient XML API errors when possible.
+
+- Use Python logging module.

--- a/bin/cert-fingerprints.sh
+++ b/bin/cert-fingerprints.sh
@@ -9,12 +9,12 @@ usage() {
 fingerprints() {
     dir=$1
 
-    echo '"filename","sha256"'
+    echo '"type","sha256"'
     for file in $(ls $dir/*.cer); do
 	fp=$(openssl x509 -noout -fingerprint -sha256 -in $file)
 	fp=$(echo $fp | sed -e 's/.*=//')
 	fp=$(echo $fp | sed -e 's/://g')
-	echo \"$(basename $file)\",\"$fp\"
+	echo \"root\",\"$fp\"
     done
 }
 

--- a/bin/chainring.py
+++ b/bin/chainring.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (c) 2024 Palo Alto Networks, Inc.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import argparse
+import asyncio
+from html import escape
+import json
+import os
+import sys
+from treelib import Tree
+
+libpath = os.path.dirname(os.path.abspath(__file__))
+sys.path[:0] = [os.path.join(libpath, os.pardir)]
+
+from pan_chainguard import title, __version__
+import pan_chainguard.util
+
+args = None
+
+
+def format_text(tree):
+    txt = tree.show(stdout=None)
+    print(txt, end='')
+
+
+def format_rst(tree):
+    def tree_to_rst(tree, node_id=None, level=0):
+        if node_id is None:
+            node_id = tree.root
+
+        node = tree[node_id]
+        lines = [f'{"  " * level}* {node.tag}']
+
+        for i, child in enumerate(tree.children(node_id)):
+            if i == 0:
+                lines.append('')
+            lines.extend(tree_to_rst(tree, child.identifier, level + 1))
+
+        return lines
+
+    lines = tree_to_rst(tree)
+    rst = ''
+    if args.title:
+        rst = f'{args.title}\n{"=" * len(args.title)}\n'
+    rst += '\n'.join(lines)
+    print(rst)
+
+
+def format_html(tree):
+    def tree_to_html(tree, node_id=None):
+        if node_id is None:
+            node_id = tree.root
+
+        node = tree[node_id]
+        children = tree.children(node_id)
+
+        html = f'<li>{escape(node.tag)}\n'
+
+        if children:
+            html += '<ul>'
+            for child in children:
+                html += tree_to_html(tree, child.identifier)
+            html += '</ul>\n'
+
+        html += '</li>\n'
+
+        return html
+
+    html = ''
+    if args.title:
+        html += f'<h1>{escape(args.title)}</h1>\n'
+    html += f'<ul>{tree_to_html(tree)}</ul>'
+    print(html)
+
+
+def format_json(tree):
+    data = pan_chainguard.util.tree_to_dict(tree=tree)
+    json_data = json.dumps(data, indent=4)
+    print(json_data)
+
+
+formats = {
+    'txt': format_text,
+    'rst': format_rst,
+    'html': format_html,
+    'json': format_json,
+}
+
+
+def main():
+    global args
+    args = parse_args()
+
+    ret = asyncio.run(main_loop())
+
+    sys.exit(ret)
+
+
+async def main_loop():
+    tree = read_tree()
+
+    if tree and args.format:
+        for format in args.format:
+            formats[format](tree)
+
+    return 0
+
+
+def read_tree():
+    if not args.tree:
+        return
+
+    try:
+        with open(args.tree, 'r') as f:
+            json_data = f.read()
+        data = json.loads(json_data)
+    except (OSError, TypeError) as e:
+        print('%s: %s' % (args.tree, e), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        tree = pan_chainguard.util.dict_to_tree(data=data)
+    except pan_chainguard.util.UtilError as e:
+        print('%s: %s' % (args.tree, e), file=sys.stderr)
+        sys.exit(1)
+
+    return tree
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s [options]',
+        description='generate documents from certificate tree')
+    parser.add_argument('--tree',
+                        required=True,
+                        metavar='PATH',
+                        help='JSON certificate tree path')
+    parser.add_argument('-f', '--format',
+                        required=True,
+                        action='append',
+                        choices=formats.keys(),
+                        help='output format')
+    parser.add_argument('-t', '--title',
+                        help='report title')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='enable verbosity')
+    parser.add_argument('--debug',
+                        type=int,
+                        choices=[0, 1, 2, 3],
+                        default=0,
+                        help='enable debug')
+    x = '%s %s' % (title, __version__)
+    parser.add_argument('--version',
+                        action='version',
+                        help='display version',
+                        version=x)
+    args = parser.parse_args()
+
+    if args.debug:
+        print(args, file=sys.stderr)
+
+    return args
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/fling.py
+++ b/bin/fling.py
@@ -36,6 +36,7 @@ libpath = os.path.dirname(os.path.abspath(__file__))
 sys.path[:0] = [os.path.join(libpath, os.pardir)]
 
 from pan_chainguard import (title, __version__)
+from pan_chainguard.util import s1_in_s2
 
 args = None
 
@@ -136,16 +137,6 @@ def api_request(xapi, func, kwargs, status=None, status_code=None):
                xapi.status_code, status_code),
               file=sys.stderr)
         sys.exit(1)
-
-
-def s1_in_s2(s1, s2):
-    if isinstance(s2, str):
-        return s1 == s2
-    elif isinstance(s2, list):
-        return s1 in s2
-    else:
-        raise ValueError('Invalid type for s2. '
-                         'Must be a string or a list of strings.')
 
 
 def create_archive(store=None, test=False):

--- a/bin/link.py
+++ b/bin/link.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (c) 2024 Palo Alto Networks, Inc.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import aiohttp
+import argparse
+import asyncio
+import os
+import sys
+import time
+
+libpath = os.path.dirname(os.path.abspath(__file__))
+sys.path[:0] = [os.path.join(libpath, os.pardir)]
+
+from pan_chainguard import title, __version__
+from pan_chainguard.ccadb import *
+from pan_chainguard.crtsh import ArgsError, CrtShApi
+import pan_chainguard.mozilla
+import pan_chainguard.util
+
+MAX_TASKS = 3  # concurrent crt.sh API requests
+CRT_SH_TIMEOUT = 60
+
+args = None
+
+
+def main():
+    global args
+    args = parse_args()
+
+    ret = asyncio.run(main_loop())
+
+    sys.exit(ret)
+
+
+async def main_loop():
+    if not pan_chainguard.util.is_writable(args.certs_new):
+        print('%s: not writable' % args.certs_new, file=sys.stderr)
+        sys.exit(1)
+
+    fingerprints = []
+    for x in args.fingerprints:
+        try:
+            fingerprints.extend(
+                pan_chainguard.util.read_fingerprints(path=x))
+        except pan_chainguard.util.UtilError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
+    mozilla = []
+    if args.certs_mozilla:
+        for x in args.certs_mozilla:
+            try:
+                mozilla.append(
+                    pan_chainguard.mozilla.MozillaCaCerts(path=x))
+            except pan_chainguard.mozilla.MozillaError as e:
+                print(str(e), file=sys.stderr)
+                sys.exit(1)
+
+    certs_old = {}
+    if args.certs_old:
+        try:
+            certs_old = pan_chainguard.util.read_cert_archive(
+                path=args.certs_old)
+        except pan_chainguard.util.UtilError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
+    errors, certs = await get_certs(fingerprints, mozilla, certs_old)
+
+    try:
+        pan_chainguard.util.write_cert_archive(
+            path=args.certs_new, data=certs)
+    except pan_chainguard.util.UtilError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if args.verbose:
+        print('Total certs-new: %d' % len(certs))
+
+    return 2 if errors else 0
+
+
+async def get_certs(fingerprints, mozilla, certs_old):
+    certs = {}
+    crtsh_download = {}
+    total_certs_old = 0
+    total_mozilla = {
+        'MozillaIntermediateCerts': 0,
+        'PublicAllIntermediateCerts': 0,
+    }
+    total_crtsh = 0
+
+    for row in fingerprints:
+        cert_type = row['type']
+        sha256 = row['sha256']
+
+        # may be duplicates in multiple fingerprint files
+        if sha256 in certs:
+            continue
+
+        if sha256 in certs_old:
+            total_certs_old += 1
+            certs[sha256] = certs_old[sha256]
+            continue
+
+        if cert_type == 'intermediate':
+            for mozilla_certs in mozilla:
+                pem = mozilla_certs.get_cert_pem(sha256=sha256)
+                if pem is not None:
+                    total_mozilla[mozilla_certs.name] += 1
+                    certs[sha256] = (cert_type, pem)
+                    break
+            if sha256 in certs:
+                continue
+
+        crtsh_download[sha256] = cert_type
+
+    errors, certificates = await get_cert_files(crtsh_download.keys())
+    for sha256 in certificates:
+        total_crtsh += 1
+        certs[sha256] = (crtsh_download[sha256], certificates[sha256])
+
+    if args.verbose:
+        print('certs-old: %d' % total_certs_old)
+        for x in total_mozilla:
+            print('%s: %d' % (x, total_mozilla[x]))
+        print('crt.sh: %d' % total_crtsh)
+
+    return errors, certs
+
+
+async def download(api, sha256):
+    tries = 0
+    MAX_TRIES = 5
+    RETRY_SLEEP = 5.0
+
+    RETRY_STATUS = [
+        429,  # Too Many Requests
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+        504,  # Gateway Time-out
+    ]
+
+    while True:
+        tries += 1
+        try:
+            if args.verbose and tries == 1:
+                print('Download using crt.sh API %s' % sha256)
+
+            resp = await api.download(id=sha256)
+
+            if resp.status in RETRY_STATUS:
+                x = '%d %s %s' % (
+                    resp.status, resp.reason, sha256)
+                if tries == MAX_TRIES:
+                    print('no retry after try %d %s' % (tries, x),
+                          file=sys.stderr)
+                    x = 'download failed ' + x
+                    break
+                print('retry after try %d %s' % (tries, x),
+                      file=sys.stderr)
+                await asyncio.sleep(RETRY_SLEEP)
+            elif resp.status != 200:
+                x = 'download failed %d %s %s' % (
+                    resp.status, resp.reason, sha256)
+                break
+            else:
+                filename, content = await api.content(resp=resp)
+
+                start = '-----BEGIN CERTIFICATE-----'
+                end = '-----END CERTIFICATE-----\n'
+                if (content.startswith(start) and
+                   content.endswith(end)):
+                    return content, sha256
+                else:
+                    # XXX ephemeral?
+                    x = 'content malformed %s %s' % (
+                        sha256, content)
+                    if tries == MAX_TRIES:
+                        print('no retry after try %d %s' % (tries, x),
+                              file=sys.stderr)
+                        x = 'download failed ' + x
+                        break
+                    print('retry after try %d %s' % (tries, x),
+                          file=sys.stderr)
+                    await asyncio.sleep(RETRY_SLEEP)
+
+        except (asyncio.TimeoutError,
+                asyncio.CancelledError,  # XXX
+                aiohttp.ClientError) as e:
+            msg = e if str(e) else type(e).__name__
+            x = 'CrtShApi: %s %s' % (msg, sha256)
+            if tries == MAX_TRIES:
+                print('no retry after try %d %s' % (tries, x),
+                      file=sys.stderr)
+                x = 'download failed ' + x
+                break
+            print('retry after try %d %s' % (tries, x),
+                  file=sys.stderr)
+            # no sleep
+
+        except ArgsError as e:
+            x = 'CrtShApi: %s' % e
+            break
+
+    return None, x
+
+
+async def get_cert_files(sha256):
+    user_agent = '%s/%s' % (title, __version__)
+    headers = {'user-agent': user_agent}
+
+    try:
+        api = CrtShApi(timeout=CRT_SH_TIMEOUT, headers=headers)
+    except ArgsError as e:
+        print('CrtShApi: %s' % e, file=sys.stderr)
+        sys.exit(1)
+    else:
+        errors, certificates = await download_certs(api, sha256)
+    finally:
+        await api.session.close()
+
+    return errors, certificates
+
+
+async def download_certs(api, sha256):
+    certificates = {}
+    tasks = []
+    start = time.time()
+    total = 0
+    errors = 0
+
+    for x in sha256:
+        total += 1
+        tasks.append(download(api, x))
+
+        if len(tasks) == MAX_TASKS:
+            errors += await run_tasks(tasks, certificates)
+            tasks = []
+
+    if len(tasks):
+        errors += await run_tasks(tasks, certificates)
+
+    if args.debug:
+        end = time.time()
+        elapsed = end - start
+        mins = elapsed // 60
+        secs = elapsed % 60
+        avg = elapsed / total if total > 0 else 0
+        print('%d tasks, elapsed %.2f seconds, %dm%ds, avg %.2fs' %
+              (total, elapsed, mins, secs, avg),
+              file=sys.stderr)
+
+    return errors, certificates
+
+
+async def run_tasks(tasks, certificates):
+    INTERVAL_WAIT = 3.3  # random throttle sweet spot to avoid TimeoutError
+    errors = 0
+
+    if args.debug:
+        print('running %d tasks' % len(tasks),
+              file=sys.stderr)
+        start = time.time()
+
+    for coro in asyncio.as_completed(tasks):
+        content, sha256 = await coro
+        if content is None:
+            # error
+            print(sha256, file=sys.stderr)
+            errors += 1
+        else:
+            certificates[sha256] = content
+
+    if args.debug:
+        end = time.time()
+        elapsed = end - start
+        rate = len(tasks) / elapsed
+        rate2 = elapsed / len(tasks)
+        print('%d tasks complete, elapsed %.2f seconds, '
+              '%.2f tasks/sec, %.2f secs/task' %
+              (len(tasks), elapsed, rate, rate2), file=sys.stderr)
+        print('sleeping %.2fs' % INTERVAL_WAIT, file=sys.stderr)
+        await asyncio.sleep(INTERVAL_WAIT)
+
+    return errors
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s [options]',
+        description='get CA certificates')
+    parser.add_argument('-f', '--fingerprints',
+                        required=True,
+                        action='append',
+                        metavar='PATH',
+                        help='CA fingerprints CSV path')
+    parser.add_argument('-m', '--certs-mozilla',
+                        action='append',
+                        metavar='PATH',
+                        help='Mozilla certs with PEM CSV path')
+    parser.add_argument('--certs-old',
+                        metavar='PATH',
+                        help='old certificate archive path')
+    parser.add_argument('--certs-new',
+                        required=True,
+                        metavar='PATH',
+                        help='new certificate archive path')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='enable verbosity')
+    parser.add_argument('--debug',
+                        type=int,
+                        choices=[0, 1, 2, 3],
+                        default=0,
+                        help='enable debug')
+    x = '%s %s' % (title, __version__)
+    parser.add_argument('--version',
+                        action='version',
+                        help='display version',
+                        version=x)
+    args = parser.parse_args()
+
+    if args.debug:
+        print(args, file=sys.stderr)
+
+    return args
+
+
+if __name__ == '__main__':
+    main()

--- a/pan_chainguard/mozilla.py
+++ b/pan_chainguard/mozilla.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2024 Palo Alto Networks, Inc.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import csv
+from typing import Optional
+
+
+class MozillaError(Exception):
+    pass
+
+
+# https://wiki.mozilla.org/CA/Intermediate_Certificates
+#
+# Intermediate CA Certificates:
+# https://ccadb.my.salesforce-sites.com/mozilla/PublicAllIntermediateCertsWithPEMCSV
+#
+
+# Non-revoked, non-expired Intermediate CA Certificates chaining up
+# to roots in Mozilla's program with the Websites trust bit set:
+# https://ccadb.my.salesforce-sites.com/mozilla/MozillaIntermediateCertsCSVReport
+
+class MozillaCaCerts:
+    def __init__(self, *,
+                 path: str):
+        def insert(row):
+            self.certs[row[SHA256]] = row[PEM]
+
+        self.certs = {}
+        self.name = None
+
+        try:
+            with open(path, 'r', newline='') as csvfile:
+                reader = csv.DictReader(csvfile,
+                                        dialect='unix')
+                row = next(reader)
+                if 'SHA256' in row and 'PEM' in row:
+                    SHA256 = 'SHA256'
+                    PEM = 'PEM'
+                    self.name = 'MozillaIntermediateCerts'
+                elif ('SHA-256 Fingerprint' in row and
+                      'PEM Info' in row):
+                    SHA256 = 'SHA-256 Fingerprint'
+                    PEM = 'PEM Info'
+                    self.name = 'PublicAllIntermediateCerts'
+                else:
+                    raise MozillaError('Invalid CSV')
+                insert(row)
+
+                for row in reader:
+                    insert(row)
+
+        except OSError as e:
+            raise MozillaError(str(e))
+
+    def get_cert_pem(self, *, sha256: str) -> Optional[str]:
+        if sha256 not in self.certs:
+            return
+
+        pem = self.certs[sha256]
+
+        # XXX PublicAllIntermediateCertsWithPEMReport.csv has
+        # single quotes around the PEM.
+        c = "'"
+        if pem.startswith(c):
+            pem = pem[1:]
+        if pem.endswith(c):
+            pem = pem[:-1]
+
+        return pem

--- a/pan_chainguard/util.py
+++ b/pan_chainguard/util.py
@@ -1,0 +1,181 @@
+#
+# Copyright (c) 2024 Palo Alto Networks, Inc.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import csv
+import io
+import os
+import re
+import tarfile
+import time
+import treelib
+from typing import Union
+
+NAME_PREFIX = 'LINK-'
+NAME_RE = r'^%s%s$' % (NAME_PREFIX, '[A-F0-9]{26,26}')
+
+
+class UtilError(Exception):
+    pass
+
+
+def s1_in_s2(s1: str, s2: Union[str, list[str]]) -> bool:
+    if isinstance(s2, str):
+        return s1 == s2
+    elif isinstance(s2, list):
+        return s1 in s2
+    else:
+        raise ValueError('Invalid type for s2. '
+                         'Must be a string or a list of strings.')
+
+
+def is_writable(path: str) -> bool:
+    # Check if the file exists
+    if os.path.exists(path):
+        # If the file exists, check if it is writable
+        return os.access(path, os.W_OK)
+    else:
+        # If the file doesn't exist, check if the directory is writable
+        parent_dir = os.path.dirname(path) or '.'
+        return os.access(parent_dir, os.W_OK)
+
+
+def read_cert_archive(*, path: str) -> dict[str, tuple[str, str]]:
+    def parse_name(name):
+        pat = (r'^(intermediate|root)/'
+               r'[0-9A-F]{64,64}\.pem$')
+        if not re.search(pat, name):
+            e = 'malformed path in archive: %s' % name
+            raise UtilError(e)
+        type_, pem = os.path.split(name)
+        sha256 = pem[:64]
+
+        return type_, sha256
+
+    data = {}
+    try:
+        with tarfile.open(name=path, mode='r') as tar:
+            for member in tar:
+                cert_type, sha256 = parse_name(member.name)
+                f = tar.extractfile(member)
+                content = f.read()
+                data[sha256] = (cert_type, content)
+
+    except (tarfile.TarError, OSError) as e:
+        raise UtilError(str(e))
+
+    return data
+
+
+def write_cert_archive(*, path: str, data: dict[str, tuple[str, str]]):
+    try:
+        with tarfile.open(name=path, mode='w:gz') as tar:
+            for k, v in data.items():
+                name = os.path.join(v[0], k + '.pem')
+                member = tarfile.TarInfo(name=name)
+                member.size = len(v[1])
+                member.mtime = time.time()
+                content = (v[1].encode() if isinstance(v[1], str)
+                           else v[1])
+                f = io.BytesIO(content)
+                tar.addfile(member, fileobj=f)
+    except (tarfile.TarError, OSError) as e:
+        raise UtilError(str(e))
+
+
+def hash_to_name(*, sha256: str) -> str:
+    # PAN-OS certificate-name max len 63
+    # Panorama certificate-name max len 31
+    # PAN-99186 won't do
+    x = NAME_PREFIX + sha256
+    return x[0:31]
+
+
+def read_fingerprints(*, path: str) -> list[dict[str, str]]:
+    try:
+        with open(path, 'r', newline='') as csvfile:
+            reader = csv.DictReader(csvfile,
+                                    dialect='unix')
+            x = []
+            for row in reader:
+                x.append(row)
+    except OSError as e:
+        raise UtilError(str(e))
+
+    return x
+
+
+def write_fingerprints(*, path: str, data: list[dict[str, str]]):
+    fieldnames = [
+        'type',
+        'sha256',
+    ]
+
+    try:
+        with open(path, 'w', newline='') as csvfile:
+            writer = csv.DictWriter(csvfile,
+                                    dialect='unix',
+                                    fieldnames=fieldnames)
+            writer.writeheader()
+            for x in data:
+                row = {
+                    'type': x['type'],
+                    'sha256': x['sha256'],
+                }
+                writer.writerow(row)
+
+    except OSError as e:
+        raise UtilError(str(e))
+
+
+def tree_to_dict(*, tree: treelib.Tree) -> dict:
+    nodes = []
+
+    for node in tree.all_nodes():
+        parent = tree.parent(node.identifier)
+        parent = parent if parent is None else parent.identifier
+        x = {
+            'identifier': node.identifier,
+            'tag': node.tag,
+            'data': node.data,
+            'parent': parent,
+        }
+        nodes.append(x)
+
+    return {'nodes': nodes}
+
+
+def dict_to_tree(*, data: dict) -> treelib.Tree:
+    root = {
+        'identifier': 0,
+        'tag': 'Root',
+        'parent': None,
+        'data': None,
+    }
+
+    if ('nodes' not in data or
+       data['nodes'][0] != root):
+        raise UtilError('Malformed tree dict')
+
+    tree = treelib.Tree()
+
+    for x in data['nodes']:
+        tree.create_node(
+            identifier=x['identifier'],
+            tag=x['tag'],
+            parent=x['parent'],
+            data=x['data'])
+
+    return tree

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = pan-chainguard
 version = attr: pan_chainguard.__version__
 author = Palo Alto Networks, Inc.
 author_email = devrel@paloaltonetworks.com
-description = Preload Trusted CA Intermediate Certificate Chains on PAN-OS
+description = Manage Root Store and Intermediate Certificate Chains on PAN-OS
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://github.com/PaloAltoNetworks/pan-chainguard
@@ -19,9 +19,12 @@ scripts =
     bin/fling.py
     bin/sprocket.py
     bin/chain.py
+    bin/chainring.py
+    bin/link.py
     bin/guard.py
     bin/cert-fingerprints.sh
 install_requires =
     aiohttp>=3.9.0
     pan-python>=0.25.0
+    treelib>=1.7.0
 python_requires = >=3.9


### PR DESCRIPTION
- Split chain.py into separate programs for:

  - Intermediate certificate determination (chain.py)
  - Certificate download (link.py)

- Re-implement chain.py to use a tree (using treelib package).

- Add chainring.py to generate documents from JSON certificate tree.

- Get CA certificates program (link.py) can use alternate certificate sources before downloading from crt.sh.

- Allow update of root store only, without adding intermediate certificates.

- Certificate name on PAN-OS has been changed to 'LINK-[0-9A-F]{26,26}' (sequence number replaced by 'LINK').